### PR TITLE
feat : api 디렉토리 정리 및 기본 데이터 패칭 구조 확립(가안)

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,0 +1,24 @@
+import { errorHandler } from "./custom";
+import { BASE_URL } from "./custom";
+export async function signupRequest(
+  nickname: string,
+  loginId: string,
+  password: string,
+) {
+  return fetch(`${BASE_URL}/signup`, {
+    method: "POST",
+    body: JSON.stringify({
+      nickname,
+      loginId,
+      password,
+    }),
+  }).then(errorHandler);
+}
+
+// 나중에 제너릭 사용해야 함
+export async function loginRequest(loginId: string, password: string) {
+  return fetch(`${BASE_URL}/login`, {
+    method: "POST",
+    body: JSON.stringify({ loginId, password }),
+  }).then(errorHandler);
+}

--- a/src/apis/custom.ts
+++ b/src/apis/custom.ts
@@ -1,0 +1,8 @@
+export const BASE_URL = "http://example.com/api";
+
+export function errorHandler(res: Response) {
+  if (!res.ok) {
+    throw new Error(`error status: ${res.status}`);
+  }
+  return res.json();
+}

--- a/src/apis/home.ts
+++ b/src/apis/home.ts
@@ -1,0 +1,7 @@
+import { errorHandler } from "./custom";
+import { BASE_URL } from "./custom";
+import { BoxOfficeListType } from "./type";
+
+export async function getBoxofficeList(): Promise<BoxOfficeListType> {
+  return fetch(`${BASE_URL}/boxoffice`).then(errorHandler);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,4 @@
 import "./index.css";
-import React from "react";
 import ReactDOM from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import Layout from "./pages/Layout.tsx";
@@ -49,7 +48,5 @@ const router = createBrowserRouter([
 ]);
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
+  <RouterProvider router={router} />,
 );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,20 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-
+import { getBoxofficeList } from "../apis/home";
+import { MovieType } from "../type";
 export default function MainPage() {
+  const [boxOfficeList, setBoxofficeList] = useState<MovieType[] | null>(null);
+
+  useEffect(() => {
+    getBoxofficeList()
+      .then((data) => {
+        setBoxofficeList(data);
+      })
+      .catch((error) => {
+        alert(error.message);
+      });
+  }, []);
+
   return (
     <div>
       <h1>메인 페이지</h1>

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,0 +1,11 @@
+type MovieType = {
+  name: string;
+  releaseYear: string;
+  country: string;
+  posterUrl: string;
+  rating: number;
+};
+
+type BoxOfficeListType = {
+  boxofficeList: Movietype[];
+};


### PR DESCRIPTION
### 이 PR은 머지하지 않습니다
API 요청과 data fetching을 어떻게 할 지 논의 해봐야 할 것 같습니다

### 코드 설명 (가안입니다)
- api 폴더에서 기능 별로 파일을 분리하고 (auth , home , content, comment 등등) 거기서 fetch 함수를 작성합니다
- type은 src 밑에 type.ts로 관리합니다 
- 데이터 패칭 시에 리액트의 기본적인 데이터 패칭 방식(useEffect에서 데이터 패칭 및 오류 핸들링 + state로 관리) 을 사용합니다.

### 논의 해봐야 할 것
1. 다른 데이터 패칭 방식을 사용해볼 것인가? (지금 제가 적은 코드에서 세부 사항이나 코드 구조 자체에 대해서도 얘기해주시면 됩니다. 이 코드 갈아엎어도 되니 의견 부탁드려요 !!)
2. 지금의 코드 방식을 사용하는 경우 loading과 error도 data 처럼 상태로 관리할 것인지
3. **페이지 별로 데이터를 한번에 받기** (메인 페이지의 경우 박스오피스 캐러셀, 최신영화 캐러셀 데이터가 묶여 하나의 json으로 한번에 data fetching 이 이루어진다. 이 경우에는 페이지별 기본적으로 하나의 엔드포인트만 있으면 됨) **vs** **각 섹션 별로 받기** ( 박스 오피스 리스트 api 엔드 포인트 , 최신영화 리스트 api 엔드포인트 리스트가 따로 있어서 각각 따로 데이터 패칭을 한다)

### 생각 중인 대안
위 코드에서는 페이지 전환마다 항상 데이터 패칭이 새롭게 일어나므로 몇가지 대안이 좋아보이긴 합니다
- 페이지별 데이터를 context로 전역관리
- 외부 라이브러리 (사용한다면 리액트쿼리가 좋아보입니다 리덕스는 복잡해서 개인적으로 비선호)